### PR TITLE
DIP-2: Coupon Redemptions

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -52,7 +52,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 25e18; // 25 DSD
+    uint256 private constant ADVANCE_INCENTIVE = 50e18; // 50 DSD
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 36; // 36 epochs fluid
 
     /* Pool */
@@ -61,6 +61,8 @@ library Constants {
     /* Market */
     uint256 private constant COUPON_EXPIRATION = 360;
     uint256 private constant DEBT_RATIO_CAP = 35e16; // 35%
+    uint256 private constant INITIAL_COUPON_REDEMPTION_PENALTY = 50e16; // 50%
+    uint256 private constant COUPON_REDEMPTION_PENALTY_DECAY = 3600; // 1 hour
 
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_DIVISOR = 12e18; // 12
@@ -132,6 +134,14 @@ library Constants {
 
     function getDebtRatioCap() internal pure returns (Decimal.D256 memory) {
         return Decimal.D256({value: DEBT_RATIO_CAP});
+    }
+    
+    function getInitialCouponRedemptionPenalty() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: INITIAL_COUPON_REDEMPTION_PENALTY});
+    }
+
+    function getCouponRedemptionPenaltyDecay() internal pure returns (uint256) {
+        return COUPON_REDEMPTION_PENALTY_DECAY;
     }
 
     function getSupplyChangeLimit() internal pure returns (Decimal.D256 memory) {

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,6 +31,12 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
+        // committer reward:
+        mintToAccount(msg.sender, 100e18); // 100 DSD to committer
+        // contributor  rewards:
+        mintToAccount(0xF414CFf71eCC35320Df0BB577E3Bc9B69c9E1f07, 1000e18); // 1000 DSD to devnull
+        mintToAccount(0x8908b99821967e7f321b1D8e485658e48F10E483,  800e18); //  800 DSD to AlexL
+        mintToAccount(0x7a03b2e8ACe63164896717C1b22647aA450954A7,  500e18); //  500 DSD to Dr Disben
     }
 
     function advance() external incentivized {

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -30,6 +30,7 @@ contract Market is Comptroller, Curve {
     event CouponExpiration(uint256 indexed epoch, uint256 couponsExpired, uint256 lessRedeemable, uint256 lessDebt, uint256 newBonded);
     event CouponPurchase(address indexed account, uint256 indexed epoch, uint256 dollarAmount, uint256 couponAmount);
     event CouponRedemption(address indexed account, uint256 indexed epoch, uint256 couponAmount);
+    event CouponBurn(address indexed account, uint256 indexed epoch, uint256 couponAmount);
     event CouponTransfer(address indexed from, address indexed to, uint256 indexed epoch, uint256 value);
     event CouponApproval(address indexed owner, address indexed spender, uint256 value);
 
@@ -65,6 +66,23 @@ contract Market is Comptroller, Curve {
         return calculateCouponPremium(dollar().totalSupply(), totalDebt(), amount);
     }
 
+    function couponRedemptionPenalty(uint256 couponEpoch, uint256 couponAmount) public view returns (uint256) {
+        uint timeIntoEpoch = block.timestamp % Constants.getEpochStrategy().period;
+        uint couponAge = epoch() - couponEpoch;
+
+        uint couponEpochDecay = Constants.getCouponRedemptionPenaltyDecay() /  Constants.getCouponExpiration() * (Constants.getCouponExpiration() - couponAge);
+
+        if(timeIntoEpoch > couponEpochDecay) {
+            return 0;
+        }
+
+        Decimal.D256 memory couponEpochInitialPenalty = Constants.getInitialCouponRedemptionPenalty().div(Decimal.D256({value: Constants.getCouponExpiration() })).mul(Decimal.D256({value: Constants.getCouponExpiration() - couponAge}));
+
+        Decimal.D256 memory couponEpochDecayedPenalty = couponEpochInitialPenalty.div(Decimal.D256({value: couponEpochDecay})).mul(Decimal.D256({value: couponEpochDecay - timeIntoEpoch}));
+
+        return Decimal.D256({value: couponAmount}).mul(couponEpochDecayedPenalty).value;
+    }
+
     function purchaseCoupons(uint256 dollarAmount) external returns (uint256) {
         Require.that(
             dollarAmount > 0,
@@ -91,9 +109,14 @@ contract Market is Comptroller, Curve {
     function redeemCoupons(uint256 couponEpoch, uint256 couponAmount) external {
         require(epoch().sub(couponEpoch) >= 2, "Market: Too early to redeem");
         decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
-        redeemToAccount(msg.sender, couponAmount);
+        
+        uint burnAmount = couponRedemptionPenalty(couponEpoch, couponAmount);
+        uint256 redeemAmount = couponAmount - burnAmount;
+        
+        redeemToAccount(msg.sender, redeemAmount);
 
-        emit CouponRedemption(msg.sender, couponEpoch, couponAmount);
+        emit CouponBurn(msg.sender, couponEpoch, burnAmount);
+        emit CouponRedemption(msg.sender, couponEpoch, redeemAmount);
     }
 
     function approveCoupons(address spender, uint256 amount) external {


### PR DESCRIPTION
**Current Situation:**
The current coupon implementation has several weaknesses, some of them being:

- There is no incentive to buy into coupons early
  - Most coupons are being bought in the same epoch
- Bots are fighting for redemptions paying tens of thousands of GWEI to redeem early
  - Technically less sophisticated actors are loosing faith to buy coupons as bot operators will snipe to redeem newer coupons before they can redeem older ones.
  - Bot operators are selling off earned tokens to cover for high transaction fees.

**Proposed Changes:**
We are proposing a penalty on out-of-order coupon redemptions during the first hour of each epoch. 

This penalty would be burned and thereby benefits all DSD holders.

The penalty is starting at 
`50% / COUPON_EXPIRATION_EPOCHS * (COUPON_EXPIRATION_EPOCHS - COUPON_AGE)`
and is decaying linearly over 
`1 hour / COUPON_EXPIRATION_EPOCHS * (COUPON_EXPIRATION_EPOCHS - COUPON_AGE)`
This gives older coupons a lower penalty at the beginning of the epoch and a faster decay than newer epochs.

<img src="https://user-images.githubusercontent.com/75574782/101289172-1f841180-37fb-11eb-95a6-f61ae4ffed6e.png" height="300" />

**Goals:**
- Give older coupons an advantage over newer ones, so people are incentivised to buy into coupons early
- Prevent a gas-war at one specific point in time as every epoch has a different time where the penalty approaches 0 and every holder a different urgency to redeem (penalty he is willing to accept)
- Newer epochs can still redeem before older ones, but need to pay a penalty to all other holders.

**Minor Additions:**
- Raise the advance incentive to 50 DSD

**Incentives and Rewards**
- 100 DSD to committer
- 1000 DSD to devnull
- 800 DSD to AlexL
- 500 DSD to Dr Disben