### PR TITLE
DIP-9: debt accumulation

### DIFF
--- a/protocol/.gitignore
+++ b/protocol/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/protocol/contracts/dao/Bonding.sol
+++ b/protocol/contracts/dao/Bonding.sol
@@ -44,7 +44,7 @@ contract Bonding is Setters, Permission {
         incrementEpoch();
     }
 
-    function deposit(uint256 value) external onlyFrozenOrLocked(msg.sender) {
+    function deposit(uint256 value) external {
         dollar().transferFrom(msg.sender, address(this), value);
         incrementBalanceOfStaged(msg.sender, value);
 

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -126,6 +126,14 @@ contract Getters is State {
         return epoch() >= _state.accounts[account].fluidUntil ? Account.Status.Frozen : Account.Status.Fluid;
     }
 
+    function fluidUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].fluidUntil;
+    }
+
+    function lockedUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].lockedUntil;
+    }
+
     function allowanceCoupons(address owner, address spender) public view returns (uint256) {
         return _state.accounts[owner].couponAllowances[spender];
     }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -35,8 +35,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         mintToAccount(msg.sender, 100e18); // 100 DSD to committer
         // contributor  rewards:
         mintToAccount(0xF414CFf71eCC35320Df0BB577E3Bc9B69c9E1f07, 1000e18); // 1000 DSD to devnull
-        mintToAccount(0x8908b99821967e7f321b1D8e485658e48F10E483,  800e18); //  800 DSD to AlexL
-        mintToAccount(0x7a03b2e8ACe63164896717C1b22647aA450954A7,  500e18); //  500 DSD to Dr Disben
     }
 
     function advance() external incentivized {

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -48,7 +48,7 @@ contract Regulator is Comptroller {
     }
 
     function shrinkSupply(Decimal.D256 memory price) private {
-        Decimal.D256 memory delta = limit(Decimal.one().sub(price));
+        Decimal.D256 memory delta = limit(Decimal.one().sub(price).div(Constants.getSupplyChangeDivisor()));
         uint256 newDebt = delta.mul(totalNet()).asUint256();
         increaseDebt(newDebt);
 

--- a/protocol/contracts/oracle/PoolGetters.sol
+++ b/protocol/contracts/oracle/PoolGetters.sol
@@ -106,6 +106,10 @@ contract PoolGetters is PoolState {
         return 0;
     }
 
+    function fluidUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].fluidUntil;
+    }
+
     function statusOf(address account) public view returns (PoolAccount.Status) {
         return epoch() >= _state.accounts[account].fluidUntil ?
             PoolAccount.Status.Frozen :

--- a/protocol/test/oracle/Pool.test.js
+++ b/protocol/test/oracle/Pool.test.js
@@ -356,6 +356,10 @@ describe('Pool', function () {
             expect(await this.pool.statusOf(userAddress)).to.be.bignumber.equal(FLUID);
           });
 
+          it('is fluid until', async function() {
+            expect(await this.pool.fluidUntil(userAddress)).to.be.bignumber.equal(new BN(13));
+          });
+
           it('updates users balances', async function () {
             expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(0));
             expect(await this.pool.balanceOfClaimable(userAddress)).to.be.bignumber.equal(new BN(0));

--- a/protocol/test/oracle/Pool.test.js
+++ b/protocol/test/oracle/Pool.test.js
@@ -26,7 +26,7 @@ describe('Pool', function () {
     this.dollar = await MockToken.new("Dynamic Set Dollar", "DSD", 18, {from: ownerAddress, gas: 8000000});
     this.usdc = await MockToken.new("USD//C", "USDC", 18, {from: ownerAddress, gas: 8000000});
     this.univ2 = await MockUniswapV2PairLiquidity.new({from: ownerAddress, gas: 8000000});
-    this.pool = await MockPool.new(this.usdc.address, {from: ownerAddress, gas: 8000000});
+    this.pool = await MockPool.new(this.dollar.address, this.usdc.address, this.univ2.address, {from: ownerAddress, gas: 8000000});
     await this.pool.set(this.dao.address, this.dollar.address, this.univ2.address);
   });
 


### PR DESCRIPTION
We are proposing some minor changes to the debt-accumulation mechanism while the details of DIP-8  are still being figured out.
Also we want to bundle this with the DAO-part of DIP-3  (depositing to DAO while Fluid).

Planned changes:
-  Add a supply change lag of 1/12th to negative rebases as well.
-  Allow DAO bonders to deposit more DSD while Fluid.
-  Add fluidUntil getters to DAO

This will improve UX for DAO bonders and slow down debt growth.