### PR TITLE
DIP-11: supply regulation

### DIFF
--- a/protocol/.gitignore
+++ b/protocol/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -47,7 +47,8 @@ library Constants {
 
     /* Governance */
     uint256 private constant GOVERNANCE_PERIOD = 36;
-    uint256 private constant GOVERNANCE_QUORUM = 33e16; // 33%
+    uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
+    uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 5e15; // 0.5%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 
@@ -106,6 +107,10 @@ library Constants {
 
     function getGovernanceQuorum() internal pure returns (Decimal.D256 memory) {
         return Decimal.D256({value: GOVERNANCE_QUORUM});
+    }
+
+    function getGovernanceProposalThreshold() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: GOVERNANCE_PROPOSAL_THRESHOLD});
     }
 
     function getGovernanceSuperMajority() internal pure returns (Decimal.D256 memory) {

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -66,8 +66,11 @@ library Constants {
     uint256 private constant COUPON_REDEMPTION_PENALTY_DECAY = 3600; // 1 hour
 
     /* Regulator */
-    uint256 private constant SUPPLY_CHANGE_DIVISOR = 12e18; // 12
-    uint256 private constant SUPPLY_CHANGE_LIMIT = 10e16; // 10%
+    uint256 private constant SUPPLY_CHANGE_LIMIT = 2e16; // 2%
+    uint256 private constant SUPPLY_CHANGE_DIVISOR = 25e18; // 25 > Max expansion at 1.5
+    uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 3e16; // 3%
+    uint256 private constant COUPON_SUPPLY_CHANGE_DIVISOR = 1666e16; // 16.66 > Max expansion at ~1.5
+    uint256 private constant NEGATIVE_SUPPLY_CHANGE_DIVISOR = 5e18; // 5 > Max negative expansion at 0.9
     uint256 private constant ORACLE_POOL_RATIO = 40; // 40%
 
     /**
@@ -155,6 +158,18 @@ library Constants {
 
     function getSupplyChangeDivisor() internal pure returns (Decimal.D256 memory) {
         return Decimal.D256({value: SUPPLY_CHANGE_DIVISOR});
+    }
+
+    function getCouponSupplyChangeLimit() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: COUPON_SUPPLY_CHANGE_LIMIT});
+    }
+
+    function getCouponSupplyChangeDivisor() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: COUPON_SUPPLY_CHANGE_DIVISOR});
+    }
+
+    function getNegativeSupplyChangeDivisor() internal pure returns (Decimal.D256 memory) {
+        return Decimal.D256({value: NEGATIVE_SUPPLY_CHANGE_DIVISOR});
     }
 
     function getOraclePoolRatio() internal pure returns (uint256) {

--- a/protocol/contracts/dao/Bonding.sol
+++ b/protocol/contracts/dao/Bonding.sol
@@ -44,7 +44,7 @@ contract Bonding is Setters, Permission {
         incrementEpoch();
     }
 
-    function deposit(uint256 value) external onlyFrozenOrLocked(msg.sender) {
+    function deposit(uint256 value) external {
         dollar().transferFrom(msg.sender, address(this), value);
         incrementBalanceOfStaged(msg.sender, value);
 

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -126,6 +126,14 @@ contract Getters is State {
         return epoch() >= _state.accounts[account].fluidUntil ? Account.Status.Frozen : Account.Status.Fluid;
     }
 
+    function fluidUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].fluidUntil;
+    }
+
+    function lockedUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].lockedUntil;
+    }
+
     function allowanceCoupons(address owner, address spender) public view returns (uint256) {
         return _state.accounts[owner].couponAllowances[spender];
     }

--- a/protocol/contracts/dao/Govern.sol
+++ b/protocol/contracts/dao/Govern.sol
@@ -152,6 +152,6 @@ contract Govern is Setters, Permission, Upgradeable {
         }
 
         Decimal.D256 memory stake = Decimal.ratio(balanceOf(account), totalSupply());
-        return stake.greaterThan(Decimal.ratio(1, 100)); // 1%
+        return stake.greaterThan(Constants.getGovernanceProposalThreshold());
     }
 }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -35,8 +35,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         mintToAccount(msg.sender, 100e18); // 100 DSD to committer
         // contributor  rewards:
         mintToAccount(0xF414CFf71eCC35320Df0BB577E3Bc9B69c9E1f07, 1000e18); // 1000 DSD to devnull
-        mintToAccount(0x8908b99821967e7f321b1D8e485658e48F10E483,  800e18); //  800 DSD to AlexL
-        mintToAccount(0x7a03b2e8ACe63164896717C1b22647aA450954A7,  500e18); //  500 DSD to Dr Disben
     }
 
     function advance() external incentivized {

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -48,7 +48,7 @@ contract Regulator is Comptroller {
     }
 
     function shrinkSupply(Decimal.D256 memory price) private {
-        Decimal.D256 memory delta = limit(Decimal.one().sub(price).div(Constants.getSupplyChangeDivisor()));
+        Decimal.D256 memory delta = limit(Decimal.one().sub(price).div(Constants.getNegativeSupplyChangeDivisor()), price);
         uint256 newDebt = delta.mul(totalNet()).asUint256();
         increaseDebt(newDebt);
 
@@ -57,17 +57,30 @@ contract Regulator is Comptroller {
     }
 
     function growSupply(Decimal.D256 memory price) private {
-        Decimal.D256 memory delta = limit(price.sub(Decimal.one()).div(Constants.getSupplyChangeDivisor()));
+        Decimal.D256 memory supplyChangeDivisor = Constants.getSupplyChangeDivisor();
+
+        uint256 totalRedeemable = totalRedeemable();
+        uint256 totalCoupons = totalCoupons();
+        if (totalRedeemable < totalCoupons) {
+            supplyChangeDivisor = Constants.getCouponSupplyChangeDivisor();
+        }
+
+        Decimal.D256 memory delta = limit(price.sub(Decimal.one()).div(supplyChangeDivisor), price);
         uint256 newSupply = delta.mul(totalNet()).asUint256();
         (uint256 newRedeemable, uint256 lessDebt, uint256 newBonded) = increaseSupply(newSupply);
         emit SupplyIncrease(epoch(), price.value, newRedeemable, lessDebt, newBonded);
     }
 
-    function limit(Decimal.D256 memory delta) private view returns (Decimal.D256 memory) {
+    function limit(Decimal.D256 memory delta, Decimal.D256 memory price) private view returns (Decimal.D256 memory) {
         Decimal.D256 memory supplyChangeLimit = Constants.getSupplyChangeLimit();
+        
+        uint256 totalRedeemable = totalRedeemable();
+        uint256 totalCoupons = totalCoupons();
+        if (price.greaterThan(Decimal.one()) && (totalRedeemable < totalCoupons)) {
+            supplyChangeLimit = Constants.getCouponSupplyChangeLimit();
+        }
 
         return delta.greaterThan(supplyChangeLimit) ? supplyChangeLimit : delta;
-
     }
 
     function oracleCapture() private returns (Decimal.D256 memory) {

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -48,7 +48,7 @@ contract Regulator is Comptroller {
     }
 
     function shrinkSupply(Decimal.D256 memory price) private {
-        Decimal.D256 memory delta = limit(Decimal.one().sub(price));
+        Decimal.D256 memory delta = limit(Decimal.one().sub(price).div(Constants.getSupplyChangeDivisor()));
         uint256 newDebt = delta.mul(totalNet()).asUint256();
         increaseDebt(newDebt);
 

--- a/protocol/contracts/oracle/PoolGetters.sol
+++ b/protocol/contracts/oracle/PoolGetters.sol
@@ -106,6 +106,10 @@ contract PoolGetters is PoolState {
         return 0;
     }
 
+    function fluidUntil(address account) public view returns (uint256) {
+        return _state.accounts[account].fluidUntil;
+    }
+
     function statusOf(address account) public view returns (PoolAccount.Status) {
         return epoch() >= _state.accounts[account].fluidUntil ?
             PoolAccount.Status.Frozen :

--- a/protocol/test/oracle/Pool.test.js
+++ b/protocol/test/oracle/Pool.test.js
@@ -356,6 +356,10 @@ describe('Pool', function () {
             expect(await this.pool.statusOf(userAddress)).to.be.bignumber.equal(FLUID);
           });
 
+          it('is fluid until', async function() {
+            expect(await this.pool.fluidUntil(userAddress)).to.be.bignumber.equal(new BN(13));
+          });
+
           it('updates users balances', async function () {
             expect(await this.dollar.balanceOf(userAddress)).to.be.bignumber.equal(new BN(0));
             expect(await this.pool.balanceOfClaimable(userAddress)).to.be.bignumber.equal(new BN(0));

--- a/protocol/test/oracle/Pool.test.js
+++ b/protocol/test/oracle/Pool.test.js
@@ -26,7 +26,7 @@ describe('Pool', function () {
     this.dollar = await MockToken.new("Dynamic Set Dollar", "DSD", 18, {from: ownerAddress, gas: 8000000});
     this.usdc = await MockToken.new("USD//C", "USDC", 18, {from: ownerAddress, gas: 8000000});
     this.univ2 = await MockUniswapV2PairLiquidity.new({from: ownerAddress, gas: 8000000});
-    this.pool = await MockPool.new(this.usdc.address, {from: ownerAddress, gas: 8000000});
+    this.pool = await MockPool.new(this.dollar.address, this.usdc.address, this.univ2.address, {from: ownerAddress, gas: 8000000});
     await this.pool.set(this.dao.address, this.dollar.address, this.univ2.address);
   });
 


### PR DESCRIPTION
We are re-proposing the changes outlined in DIP-9, along with additional ajustments to the supply change formula and lowering of the governance thresholds, to prevent a scenario like the DIP-9 vote from happening again.

Proposed changes:
- Lower the governance thresholds to 0.5% for a proposal, 20% for quorum
- Limit the max expansions to 2% (3% while coupons are outstanding)
- Add a supply change lag of 1/25th to expansions (16.66 while coupons are outstanding), targeting max-rebase at a TWAP of 1.5
- Add a supply change lag of 1/5th to contractions, targeting max-rebase at a TWAP of 0.9
- Allow DAO bonders to deposit more DSD while Fluid.
- Add fluidUntil getters to DAO