### PR TITLE
DIP-3: provide while fluid

### DIFF
--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -53,7 +53,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 6; // 6 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 50e18; // 50 DSD
+    uint256 private constant ADVANCE_INCENTIVE = 150e18; // 150 DSD
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 36; // 36 epochs fluid
 
     /* Pool */

--- a/protocol/contracts/Constants.sol
+++ b/protocol/contracts/Constants.sol
@@ -73,6 +73,11 @@ library Constants {
     uint256 private constant NEGATIVE_SUPPLY_CHANGE_DIVISOR = 5e18; // 5 > Max negative expansion at 0.9
     uint256 private constant ORACLE_POOL_RATIO = 40; // 40%
 
+    /* Deployed */
+    address private constant DAO_ADDRESS = address(0x6Bf977ED1A09214E6209F4EA5f525261f1A2690a);
+    address private constant DOLLAR_ADDRESS = address(0xBD2F0Cd039E0BFcf88901C98c0bFAc5ab27566e3);
+    address private constant PAIR_ADDRESS = address(0x66e33d2605c5fB25eBb7cd7528E7997b0afA55E8);
+
     /**
      * Getters
      */
@@ -178,5 +183,17 @@ library Constants {
 
     function getChainId() internal pure returns (uint256) {
         return CHAIN_ID;
+    }
+
+    function getDaoAddress() internal pure returns (address) {
+        return DAO_ADDRESS;
+    }
+
+    function getDollarAddress() internal pure returns (address) {
+        return DOLLAR_ADDRESS;
+    }
+
+    function getPairAddress() internal pure returns (address) {
+        return PAIR_ADDRESS;
     }
 }

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,8 +31,9 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
+        _state.provider.pool = address(0x6b0829dABf0b619eE7692aD20b1f987C3E9C8ECF);
         // committer reward:
-        mintToAccount(msg.sender, 100e18); // 100 DSD to committer
+        mintToAccount(msg.sender, 150e18); // 150 DSD to committer
         // contributor  rewards:
         mintToAccount(0xF414CFf71eCC35320Df0BB577E3Bc9B69c9E1f07, 1000e18); // 1000 DSD to devnull
     }

--- a/protocol/contracts/mock/MockPool.sol
+++ b/protocol/contracts/mock/MockPool.sol
@@ -25,7 +25,7 @@ contract MockPool is Pool {
     address private _dollar;
     address private _univ2;
 
-    constructor(address dollar, address usdc, address univ2) Pool(dollar, univ2) public {
+    constructor(address usdc) Pool() public {
         _usdc = usdc;
     }
 

--- a/protocol/contracts/oracle/Pool.sol
+++ b/protocol/contracts/oracle/Pool.sol
@@ -27,11 +27,7 @@ import "./Liquidity.sol";
 contract Pool is PoolSetters, Liquidity {
     using SafeMath for uint256;
 
-    constructor(address dollar, address univ2) public {
-        _state.provider.dao = IDAO(msg.sender);
-        _state.provider.dollar = IDollar(dollar);
-        _state.provider.univ2 = IERC20(univ2);
-    }
+    constructor() public { }
 
     bytes32 private constant FILE = "Pool";
 

--- a/protocol/contracts/oracle/Pool.sol
+++ b/protocol/contracts/oracle/Pool.sol
@@ -105,7 +105,7 @@ contract Pool is PoolSetters, Liquidity {
         emit Unbond(msg.sender, epoch().add(1), value, newClaimable);
     }
 
-    function provide(uint256 value) external onlyFrozen(msg.sender) notPaused {
+    function provide(uint256 value) external notPaused {
         Require.that(
             totalBonded() > 0,
             FILE,

--- a/protocol/contracts/oracle/PoolGetters.sol
+++ b/protocol/contracts/oracle/PoolGetters.sol
@@ -33,15 +33,15 @@ contract PoolGetters is PoolState {
     }
 
     function dao() public view returns (IDAO) {
-        return _state.provider.dao;
+        return IDAO(Constants.getDaoAddress());
     }
 
     function dollar() public view returns (IDollar) {
-        return _state.provider.dollar;
+        return IDollar(Constants.getDollarAddress());
     }
 
     function univ2() public view returns (IERC20) {
-        return _state.provider.univ2;
+        return IERC20(Constants.getPairAddress());
     }
 
     function totalBonded() public view returns (uint256) {


### PR DESCRIPTION
While the DAO-part of DIP-3 (deposit to DAO while fluid) was already implemented in DIP-11, this updates the Pool, with the following changes:

- Change the Pool address in the DAO to 0x6b0829dABf0b619eE7692aD20b1f987C3E9C8ECF
- Allow to provide rewards to the pool while fluid
- Adds fluidUntil getter to Pool

Minor change to DAO:
- Increase advance incentive to 150 DSD

The implementation is deployed at [0x7CA1d1A9B6B032DB7e67a5fF884aa2E53e797d32](https://etherscan.io/address/0x7CA1d1A9B6B032DB7e67a5fF884aa2E53e797d32#code)

Voting is live at https://dsd.finance/app/#/governance/candidate/0x7CA1d1A9B6B032DB7e67a5fF884aa2E53e797d32