### PR TITLE
dip-13-coupon-migration

### DIFF
--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -48,9 +48,10 @@ contract Comptroller is Setters {
     }
 
     function redeemToAccount(address account, uint256 amount, uint256 couponAmount) internal {
-        if (_state13.price.greaterThan(Decimal.one())) {
-            dollar().mint(account, amount);
-        }
+        require(_state13.price.greaterThan(Decimal.one()), "Comptroller: not in expansion");
+
+        dollar().mint(account, amount);
+
         if (couponAmount != 0) {
             dollar().transfer(account, couponAmount);
             decrementTotalRedeemable(couponAmount, "Comptroller: not enough redeemable balance");

--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -26,6 +26,10 @@ contract Comptroller is Setters {
 
     bytes32 private constant FILE = "Comptroller";
 
+    function setPrice(Decimal.D256 memory price) internal {
+        _state13.price = price;
+    }
+
     function mintToAccount(address account, uint256 amount) internal {
         dollar().mint(account, amount);
         if (!bootstrappingAt(epoch())) {
@@ -43,9 +47,14 @@ contract Comptroller is Setters {
         balanceCheck();
     }
 
-    function redeemToAccount(address account, uint256 amount) internal {
-        dollar().transfer(account, amount);
-        decrementTotalRedeemable(amount, "Comptroller: not enough redeemable balance");
+    function redeemToAccount(address account, uint256 amount, uint256 couponAmount) internal {
+        if (_state13.price.greaterThan(Decimal.one())) {
+            dollar().mint(account, amount);
+        }
+        if (couponAmount != 0) {
+            dollar().transfer(account, couponAmount);
+            decrementTotalRedeemable(couponAmount, "Comptroller: not enough redeemable balance");
+        }
 
         balanceCheck();
     }

--- a/protocol/contracts/dao/Comptroller.sol
+++ b/protocol/contracts/dao/Comptroller.sol
@@ -48,8 +48,6 @@ contract Comptroller is Setters {
     }
 
     function redeemToAccount(address account, uint256 amount, uint256 couponAmount) internal {
-        require(_state13.price.greaterThan(Decimal.one()), "Comptroller: not in expansion");
-
         dollar().mint(account, amount);
 
         if (couponAmount != 0) {

--- a/protocol/contracts/dao/Getters.sol
+++ b/protocol/contracts/dao/Getters.sol
@@ -87,6 +87,10 @@ contract Getters is State {
         return _state.balance.redeemable;
     }
 
+    function totalCouponUnderlying() public view returns (uint256) {
+        return _state13.couponUnderlying;
+    }
+
     function totalCoupons() public view returns (uint256) {
         return _state.balance.coupons;
     }
@@ -116,6 +120,10 @@ contract Getters is State {
             return 0;
         }
         return _state.accounts[account].coupons[epoch];
+    }
+
+    function balanceOfCouponUnderlying(address account, uint256 epoch) public view returns (uint256) {
+        return _state13.couponUnderlyingByAccount[account][epoch];
     }
 
     function statusOf(address account) public view returns (Account.Status) {

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -31,8 +31,6 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
     event Incentivization(address indexed account, uint256 amount);
 
     function initialize() initializer public {
-        // initial funding for the treasury:
-        mintToAccount(Constants.getTreasuryAddress(), 2000000e18); // 2 million DSD
         // committer reward:
         mintToAccount(msg.sender, 150e18); // 150 DSD to committer
         // contributor  rewards:

--- a/protocol/contracts/dao/Implementation.sol
+++ b/protocol/contracts/dao/Implementation.sol
@@ -37,6 +37,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
         mintToAccount(msg.sender, 150e18); // 150 DSD to committer
         // contributor  rewards:
         mintToAccount(0xF414CFf71eCC35320Df0BB577E3Bc9B69c9E1f07, 1000e18); // 1000 DSD to devnull
+        mintToAccount(0x35F32d099fb9E08b706A6fa41D639EEB69F8A906, 1000e18); // 1000 DSD to degendegen9
     }
 
     function advance() external incentivized {

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -120,15 +120,17 @@ contract Market is Comptroller, Curve {
         );
 
         uint256 epoch = epoch();
-        uint256 couponAmount = couponPremium(amount);
-        incrementBalanceOfCoupons(msg.sender, epoch, couponAmount);
-        incrementBalanceOfCouponUnderlying(msg.sender, epoch, amount);
+        uint256 balanceOfCoupons = amount.add(couponPremium(amount));
+        uint256 couponUnderlying = balanceOfCoupons.div(2);
+
+        incrementBalanceOfCoupons(msg.sender, epoch, couponUnderlying);
+        incrementBalanceOfCouponUnderlying(msg.sender, epoch, couponUnderlying);
 
         burnFromAccount(msg.sender, amount);
 
-        emit CouponPurchase(msg.sender, epoch, amount, couponAmount);
+        emit CouponPurchase(msg.sender, epoch, amount, couponUnderlying);
 
-        return couponAmount;
+        return couponUnderlying;
     }
 
     function redeemCoupons(uint256 couponEpoch, uint256 amount) external {

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -130,21 +130,25 @@ contract Market is Comptroller, Curve {
             .mul(amount).div(balanceOfCouponUnderlying(msg.sender, couponEpoch), "Market: No underlying");
 
         decrementBalanceOfCouponUnderlying(msg.sender, couponEpoch, amount, "Market: Insufficient coupon underlying balance");
-        if (couponAmount != 0) decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
         
-        uint burnAmount = couponRedemptionPenalty(couponEpoch, couponAmount);
-        uint256 redeemAmount = couponAmount - burnAmount;
-        
+        uint256 burnAmount;
+        uint256 redeemAmount;
+        if (couponAmount != 0) {
+            decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
+            burnAmount = couponRedemptionPenalty(couponEpoch, couponAmount);
+            redeemAmount = couponAmount - burnAmount;
+        }
+
         redeemToAccount(msg.sender, amount, redeemAmount);
 
-        if(burnAmount > 0){
+        if(burnAmount > 0) {
             emit CouponBurn(msg.sender, couponEpoch, burnAmount);
         }
 
         emit CouponRedemption(msg.sender, couponEpoch, amount, redeemAmount);
     }
 
-    function redeemCoupons(uint256 couponEpoch, uint256 amount, uint256 minOutput) external {
+    function redeemCoupons(uint256 couponEpoch, uint256 amount, uint256 minPremiumOutput) external {
         require(epoch().sub(couponEpoch) >= 2, "Market: Too early to redeem");
 		require(amount != 0, "Market: Amount too low");
 
@@ -152,20 +156,24 @@ contract Market is Comptroller, Curve {
             .mul(amount).div(balanceOfCouponUnderlying(msg.sender, couponEpoch), "Market: No underlying");
 
         decrementBalanceOfCouponUnderlying(msg.sender, couponEpoch, amount, "Market: Insufficient coupon underlying balance");
-        if (couponAmount != 0) decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
         
-        uint burnAmount = couponRedemptionPenalty(couponEpoch, couponAmount);
-        uint256 redeemAmount = couponAmount - burnAmount;
+        uint256 burnAmount;
+        uint256 redeemAmount;
+        if (couponAmount != 0) {
+            decrementBalanceOfCoupons(msg.sender, couponEpoch, couponAmount, "Market: Insufficient coupon balance");
+            burnAmount = couponRedemptionPenalty(couponEpoch, couponAmount);
+            redeemAmount = couponAmount - burnAmount;
+        }
 
         Require.that(
-            redeemAmount >= minOutput,
+            redeemAmount >= minPremiumOutput,
             FILE,
             "Insufficient output amount"
         );
 
         redeemToAccount(msg.sender, amount, redeemAmount);
 
-        if(burnAmount > 0){
+        if(burnAmount > 0) {
             emit CouponBurn(msg.sender, couponEpoch, burnAmount);
         }
 

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -68,7 +68,7 @@ contract Market is Comptroller, Curve {
 
     function couponRedemptionPenalty(uint256 couponEpoch, uint256 couponAmount) public view returns (uint256) {
         uint timeIntoEpoch = block.timestamp % Constants.getEpochStrategy().period;
-        uint couponAge = epoch().sub(couponEpoch);
+        uint couponAge = epoch().sub(couponEpoch, "Market: Future couponEpoch");
 
         if (couponAge >= Constants.getCouponExpiration()) {
             return 0;

--- a/protocol/contracts/dao/Market.sol
+++ b/protocol/contracts/dao/Market.sol
@@ -68,11 +68,15 @@ contract Market is Comptroller, Curve {
 
     function couponRedemptionPenalty(uint256 couponEpoch, uint256 couponAmount) public view returns (uint256) {
         uint timeIntoEpoch = block.timestamp % Constants.getEpochStrategy().period;
-        uint couponAge = epoch() - couponEpoch;
+        uint couponAge = epoch().sub(couponEpoch);
+
+        if (couponAge >= Constants.getCouponExpiration()) {
+            return 0;
+        }
 
         uint couponEpochDecay = Constants.getCouponRedemptionPenaltyDecay() * (Constants.getCouponExpiration() - couponAge) / Constants.getCouponExpiration();
 
-        if(timeIntoEpoch > couponEpochDecay) {
+        if (timeIntoEpoch >= couponEpochDecay) {
             return 0;
         }
 

--- a/protocol/contracts/dao/Regulator.sol
+++ b/protocol/contracts/dao/Regulator.sol
@@ -33,6 +33,8 @@ contract Regulator is Comptroller {
     function step() internal {
         Decimal.D256 memory price = oracleCapture();
 
+        setPrice(price);
+
         if (price.greaterThan(Decimal.one())) {
             growSupply(price);
             return;

--- a/protocol/contracts/dao/Setters.sol
+++ b/protocol/contracts/dao/Setters.sol
@@ -108,10 +108,20 @@ contract Setters is State, Getters {
         _state.balance.coupons = _state.balance.coupons.add(amount);
     }
 
+    function incrementBalanceOfCouponUnderlying(address account, uint256 epoch, uint256 amount) internal {
+        _state13.couponUnderlyingByAccount[account][epoch] = _state13.couponUnderlyingByAccount[account][epoch].add(amount);
+        _state13.couponUnderlying = _state13.couponUnderlying.add(amount);
+    }
+
     function decrementBalanceOfCoupons(address account, uint256 epoch, uint256 amount, string memory reason) internal {
         _state.accounts[account].coupons[epoch] = _state.accounts[account].coupons[epoch].sub(amount, reason);
         _state.epochs[epoch].coupons.outstanding = _state.epochs[epoch].coupons.outstanding.sub(amount, reason);
         _state.balance.coupons = _state.balance.coupons.sub(amount, reason);
+    }
+
+    function decrementBalanceOfCouponUnderlying(address account, uint256 epoch, uint256 amount, string memory reason) internal {
+        _state13.couponUnderlyingByAccount[account][epoch] = _state13.couponUnderlyingByAccount[account][epoch].sub(amount, reason);
+        _state13.couponUnderlying = _state13.couponUnderlying.sub(amount, reason);
     }
 
     function unfreeze(address account) internal {

--- a/protocol/contracts/dao/State.sol
+++ b/protocol/contracts/dao/State.sol
@@ -100,8 +100,17 @@ contract Storage {
         mapping(uint256 => Epoch.State) epochs;
         mapping(address => Candidate.State) candidates;
     }
+
+    struct State13 {
+        mapping(address => mapping(uint256 => uint256)) couponUnderlyingByAccount;
+        uint256 couponUnderlying;
+        Decimal.D256 price;
+    }
 }
 
 contract State {
     Storage.State _state;
+
+    // DIP-13
+    Storage.State13 _state13;
 }


### PR DESCRIPTION
Storage split of coupon premium and principal
Premium expires and principal can be reclaimed when price > 1
Outstanding coupons can be migrated to new format and 1/2 can be reclaimed when in expansion, after expiry
Coupons past their expiration can still be migrated for 1/2 claim
Future coupon purchases are slashed 1/2 if they expire, same as past coupons